### PR TITLE
Make TNRD.UnitySteer.Editor only available to the Editor platform.

### DIFF
--- a/Editor/TNRD.UnitySteer.Editor.asmdef
+++ b/Editor/TNRD.UnitySteer.Editor.asmdef
@@ -3,7 +3,9 @@
     "references": [
         "TNRD.UnitySteer"
     ],
-    "includePlatforms": [],
+    "includePlatforms": [
+        "Editor"
+    ],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
     "overrideReferences": false,


### PR DESCRIPTION
Hi. This commit enables us to successfully build using the TNRD.UnitySteer package. (The single commit makes the TNRD.UnitySteer.Editor assembly definition only apply to the Editor platform.)